### PR TITLE
Update Splash.js

### DIFF
--- a/game/states/Splash.js
+++ b/game/states/Splash.js
@@ -9,7 +9,7 @@ Splash.prototype = {
     game.load.script('gamemenu','states/GameMenu.js');
     game.load.script('game', 'states/Game.js');
     game.load.script('gameover','states/GameOver.js');
-    game.load.script('credits', 'states/Credits.js');
+    game.load.script('Credits', 'states/credits.js');
     game.load.script('options', 'states/Options.js');
   },
 


### PR DESCRIPTION
Javascript is case-sensitive. The Credits menu option is not working correctly so I'm thinking that if the file is credits.js, then it is a syntax error to call Credits.js. I changed Credits.js to credits.js